### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 The MCP connects to the [Naver Maps API](https://www.ncloud.com/product/applicationService/maps) and [Naver Search API](https://developers.naver.com/products/service-api/search/search.md). 네이버 지도 API와 검색 API에 (로컬) 연결하는 MCP 서버.
 
+<a href="https://glama.ai/mcp/servers/@yunkee-lee/mcp-naver-maps">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@yunkee-lee/mcp-naver-maps/badge" alt="Naver Maps MCP server" />
+</a>
+
 It currently supports the following APIs:
 * [Geocoding](https://api.ncloud-docs.com/docs/application-maps-geocoding)
 * [Local saerch](https://developers.naver.com/docs/serviceapi/search/local/local.md#%EC%A7%80%EC%97%AD)


### PR DESCRIPTION
This PR adds a badge for the [MCP Naver Maps](https://glama.ai/mcp/servers/@yunkee-lee/mcp-naver-maps) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@yunkee-lee/mcp-naver-maps">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@yunkee-lee/mcp-naver-maps/badge" alt="Naver Maps MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.